### PR TITLE
[#126] デフォルトWorkflowの実装

### DIFF
--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useSearchParams, useLocation } from 'react-router-dom'
+import { AppDispatch } from 'store/store'
 
 import { selectRunPostData } from 'store/selectors/run/RunSelectors'
 import {
@@ -18,6 +19,7 @@ import { RUN_STATUS } from './PipelineType'
 import {
   fetchExperiment,
   getExperiments,
+  importExperimentByUid,
 } from '../Experiments/ExperimentsActions'
 
 const POLLING_INTERVAL = 5000
@@ -26,6 +28,7 @@ export type UseRunPipelineReturnType = ReturnType<typeof useRunPipeline>
 
 export function useRunPipeline() {
   const dispatch = useDispatch()
+  const appDispatch: AppDispatch = useDispatch()
   const uid = useSelector(selectPipelineLatestUid)
   const isCanceled = useSelector(selectPipelineIsCanceled)
   const isStartedSuccess = useSelector(selectPipelineIsStartedSuccess)
@@ -49,7 +52,13 @@ export function useRunPipeline() {
 
   React.useEffect(() => {
     const projectId = searchParams.get('id')
-    projectId && !isEdited && dispatch(fetchExperiment(projectId.toString()))
+    if (projectId && !isEdited) {
+      appDispatch(fetchExperiment(projectId.toString()))
+        .unwrap()
+        .catch((_) => {
+          dispatch(importExperimentByUid('default'))
+        })
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   const handleCancelPipeline = React.useCallback(() => {

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -63,10 +63,14 @@ export const pipelineSlice = createSlice({
         state.run.status = RUN_STATUS.ABORTED
       })
       .addCase(importExperimentByUid.fulfilled, (state, action) => {
-        state.currentPipeline = {
-          uid: action.meta.arg,
+        if (action.meta.arg === 'default') {
+          state.runBtn = RUN_BTN_OPTIONS.RUN_NEW
+        } else {
+          state.currentPipeline = {
+            uid: action.meta.arg,
+          }
+          state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
         }
-        state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
         state.run = {
           status: RUN_STATUS.START_UNINITIALIZED,
         }

--- a/optinist/api/dir_path.py
+++ b/optinist/api/dir_path.py
@@ -24,4 +24,5 @@ class DIRPATH:
 
     SNAKEMAKE_FILEPATH = f"{ROOT_DIR}/Snakefile"
     EXPERIMENT_YML = "experiment.yaml"
+    DEFAULT_EXPERIMENT_YML = "default_experiment.yaml"
     SNAKEMAKE_CONFIG_YML = "config.yaml"

--- a/optinist/default_experiment.yaml
+++ b/optinist/default_experiment.yaml
@@ -1,0 +1,248 @@
+edgeDict:
+  ? reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_25pzk690c8suite2p_file_convert_25pzk690c8--image--ImageData
+  : animated: false
+    id: reactflow__edge-input_0input_0--image--ImageData-suite2p_file_convert_25pzk690c8suite2p_file_convert_25pzk690c8--image--ImageData
+    source: input_0
+    sourceHandle: input_0--image--ImageData
+    style:
+      border: null
+      borderRadius: null
+      height: null
+      padding: null
+      width: 5
+    target: suite2p_file_convert_25pzk690c8
+    targetHandle: suite2p_file_convert_25pzk690c8--image--ImageData
+    type: buttonedge
+  ? reactflow__edge-suite2p_file_convert_25pzk690c8suite2p_file_convert_25pzk690c8--ops--Suite2pData-suite2p_registration_zf22lm1eg6suite2p_registration_zf22lm1eg6--ops--Suite2pData
+  : animated: false
+    id: reactflow__edge-suite2p_file_convert_25pzk690c8suite2p_file_convert_25pzk690c8--ops--Suite2pData-suite2p_registration_zf22lm1eg6suite2p_registration_zf22lm1eg6--ops--Suite2pData
+    source: suite2p_file_convert_25pzk690c8
+    sourceHandle: suite2p_file_convert_25pzk690c8--ops--Suite2pData
+    style:
+      border: null
+      borderRadius: null
+      height: null
+      padding: null
+      width: 5
+    target: suite2p_registration_zf22lm1eg6
+    targetHandle: suite2p_registration_zf22lm1eg6--ops--Suite2pData
+    type: buttonedge
+nodeDict:
+  input_0:
+    data:
+      fileType: image
+      hdf5Path: null
+      label: '1'
+      param:
+        alignments:
+          path: alignments
+          type: child
+          value: []
+      path:
+      - /workdb/image/2/1
+      type: input
+    id: input_0
+    position:
+      x: 50
+      y: 150
+    style:
+      border: '1px solid #777'
+      borderRadius: null
+      height: 130
+      padding: null
+      width: null
+    type: ImageFileNode
+  suite2p_file_convert_25pzk690c8:
+    data:
+      fileType: null
+      hdf5Path: null
+      label: suite2p_file_convert
+      param:
+        batch_size:
+          path: batch_size
+          type: child
+          value: 500
+        do_registration:
+          path: do_registration
+          type: child
+          value: 1
+        force_sktiff:
+          path: force_sktiff
+          type: child
+          value: false
+        nchannels:
+          path: nchannels
+          type: child
+          value: 1
+        nplanes:
+          path: nplanes
+          type: child
+          value: 1
+      path: suite2p/suite2p_file_convert
+      type: algorithm
+    id: suite2p_file_convert_25pzk690c8
+    position:
+      x: 417
+      y: 166
+    style:
+      border: null
+      borderRadius: 0
+      height: 100
+      padding: 0
+      width: 180
+    type: AlgorithmNode
+  suite2p_registration_zf22lm1eg6:
+    data:
+      fileType: null
+      hdf5Path: null
+      label: suite2p_registration
+      param:
+        1Preg:
+          path: 1Preg
+          type: child
+          value: false
+        align_by_chan:
+          path: align_by_chan
+          type: child
+          value: 1
+        bidi_corrected:
+          path: bidi_corrected
+          type: child
+          value: false
+        bidiphase:
+          path: bidiphase
+          type: child
+          value: 0
+        block_size:
+          path: block_size
+          type: child
+          value:
+          - 128
+          - 128
+        diameter:
+          path: diameter
+          type: child
+          value: 0
+        do_bidiphase:
+          path: do_bidiphase
+          type: child
+          value: false
+        frames_include:
+          path: frames_include
+          type: child
+          value: -1
+        functional_chan:
+          path: functional_chan
+          type: child
+          value: 1
+        keep_movie_raw:
+          path: keep_movie_raw
+          type: child
+          value: false
+        maxregshift:
+          path: maxregshift
+          type: child
+          value: 0.1
+        maxregshiftNR:
+          path: maxregshiftNR
+          type: child
+          value: 5
+        nonrigid:
+          path: nonrigid
+          type: child
+          value: true
+        pre_smooth:
+          path: pre_smooth
+          type: child
+          value: 0
+        reg_tif:
+          path: reg_tif
+          type: child
+          value: false
+        smooth_sigma:
+          path: smooth_sigma
+          type: child
+          value: 1.15
+        smooth_sigma_time:
+          path: smooth_sigma_time
+          type: child
+          value: 0
+        snr_thresh:
+          path: snr_thresh
+          type: child
+          value: 1.2
+        spatial_hp_reg:
+          path: spatial_hp_reg
+          type: child
+          value: 42
+        spatial_taper:
+          path: spatial_taper
+          type: child
+          value: 40
+        th_badframes:
+          path: th_badframes
+          type: child
+          value: 1
+      path: suite2p/suite2p_registration
+      type: algorithm
+    id: suite2p_registration_zf22lm1eg6
+    position:
+      x: 671
+      y: 183
+    style:
+      border: null
+      borderRadius: 0
+      height: 100
+      padding: 0
+      width: 180
+    type: AlgorithmNode
+function:
+  input_0:
+    finished_at: '2023-06-06 19:22:45'
+    hasNWB: false
+    message: null
+    name: '1'
+    outputPaths: null
+    started_at: '2023-06-06 19:22:45'
+    subjects: null
+    success: success
+    unique_id: input_0
+  suite2p_file_convert_25pzk690c8:
+    finished_at: '2023-06-06 19:23:10'
+    hasNWB: false
+    message: suite2p_file_convert success
+    name: suite2p_file_convert
+    outputPaths:
+      meanImg:
+        max_index: 1
+        path: /Users/rei_hashimoto/GitHub/MRIAnalysisStudioforMouse/files/output/2/d160e794/suite2p_file_convert_25pzk690c8/meanImg.json
+        type: images
+    started_at: '2023-06-06 19:22:52'
+    subjects: null
+    success: success
+    unique_id: suite2p_file_convert_25pzk690c8
+  suite2p_registration_zf22lm1eg6:
+    finished_at: '2023-06-06 19:23:21'
+    hasNWB: false
+    message: suite2p_registration success
+    name: suite2p_registration
+    outputPaths:
+      meanImgE:
+        max_index: 1
+        path: /Users/rei_hashimoto/GitHub/MRIAnalysisStudioforMouse/files/output/2/d160e794/suite2p_registration_zf22lm1eg6/meanImgE.json
+        type: images
+      refImg:
+        max_index: 1
+        path: /Users/rei_hashimoto/GitHub/MRIAnalysisStudioforMouse/files/output/2/d160e794/suite2p_registration_zf22lm1eg6/refImg.json
+        type: images
+    started_at: '2023-06-06 19:23:15'
+    subjects: null
+    success: success
+    unique_id: suite2p_registration_zf22lm1eg6
+project_id: default
+unique_id: default
+started_at: '2023-06-06 19:22:45'
+finished_at: '2023-06-06 19:23:21'
+success: success
+hasNWB: true
+name: New flow

--- a/optinist/routers/experiment.py
+++ b/optinist/routers/experiment.py
@@ -37,6 +37,18 @@ async def get_experiments(project_id: str):
     return exp_config
 
 
+@router.get("/experiments/import/default", response_model=ExptImportData, tags=['experiments'])
+async def import_experiment():
+    config = ExptConfigReader.read(join_filepath([
+        DIRPATH.ROOT_DIR,
+        DIRPATH.DEFAULT_EXPERIMENT_YML,
+    ]))
+    return {
+        "nodeDict": config.nodeDict,
+        "edgeDict": config.edgeDict,
+    }
+
+
 @router.get("/experiments/import/{unique_id}", response_model=ExptImportData, tags=['experiments'])
 async def import_experiment(unique_id: str):
     config = ExptConfigReader.read(join_filepath([

--- a/optinist/routers/experiment.py
+++ b/optinist/routers/experiment.py
@@ -37,7 +37,15 @@ async def get_experiments(project_id: str):
     return exp_config
 
 
-@router.get("/experiments/import/default", response_model=ExptImportData, tags=['experiments'])
+@router.get(
+    "/experiments/import/default",
+    response_model=ExptImportData,
+    description="""
+- Response default Workflow settings
+  - Default Workflow settings file: `default_experiment.yaml`
+""",
+    tags=['experiments']
+)
 async def import_experiment():
     config = ExptConfigReader.read(join_filepath([
         DIRPATH.ROOT_DIR,


### PR DESCRIPTION
#126 

## 仕様

- `optinist/default_experiment.yaml`ファイルのedgeDict, nodeDictの情報を利用してimportを行う
  - 上記以外のキーについても、ExptConfigクラスへの落とし込みがある都合でdummyで値を残している
- トリガはfetch対象のexperimentがない場合
  - この場合、`experiments/fetch/{project_id}`が404で失敗する想定
- `experimenst/import/default`のエンドポイントで呼び出し
- frontの処理としては、基本的にoptinistの`experiments/import/{uid}`と同様だが、RUNではなくRUN_ALLになるよう一部処理分岐を追加
- 現状は以下のWorkflowが再現される仕様
  ![Screenshot 2023-06-07 at 13 41 58](https://github.com/arayabrain/MRIAnalysisStudioforMouse/assets/42664619/017d621d-6a05-46a1-a65c-b3c9e1d493c2)
  
