### PR TITLE
force RUN ALL if imageset was edited

### DIFF
--- a/frontend/src/components/ImageAlignment/index.tsx
+++ b/frontend/src/components/ImageAlignment/index.tsx
@@ -82,7 +82,12 @@ const ImageAlignment: FC<ImageViewProps> = ({
           param: stateParams,
         }),
       )
-      dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
+      dispatch(
+        setRunBtnOption({
+          runBtnOption: RUN_BTN_OPTIONS.RUN_NEW,
+          runAlreadyDisabled: true,
+        }),
+      )
     }
     onClose?.()
   }

--- a/frontend/src/components/ImageAlignment/index.tsx
+++ b/frontend/src/components/ImageAlignment/index.tsx
@@ -6,6 +6,8 @@ import { useDispatch } from 'react-redux'
 import { setInputNodeParamAlignment } from 'store/slice/InputNode/InputNodeSlice'
 import { Params } from 'store/slice/InputNode/InputNodeType'
 import { DATABASE_URL_HOST } from 'const/API'
+import { setRunBtnOption } from 'store/slice/Pipeline/PipelineSlice'
+import { RUN_BTN_OPTIONS } from 'store/slice/Pipeline/PipelineType'
 import Loading from 'components/common/Loading'
 
 type ImageViewProps = {
@@ -80,6 +82,7 @@ const ImageAlignment: FC<ImageViewProps> = ({
           param: stateParams,
         }),
       )
+      dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
     }
     onClose?.()
   }

--- a/frontend/src/components/RunButtons.tsx
+++ b/frontend/src/components/RunButtons.tsx
@@ -25,7 +25,7 @@ import {
   RUN_BTN_OPTIONS,
   RUN_BTN_TYPE,
 } from 'store/slice/Pipeline/PipelineType'
-import { selectPipelineRunBtn } from 'store/slice/Pipeline/PipelineSelectors'
+import { selectPipelineRunBtn, selectRunAlreadyDisabled } from 'store/slice/Pipeline/PipelineSelectors'
 import { setRunBtnOption } from 'store/slice/Pipeline/PipelineSlice'
 
 export const RunButtons = React.memo<UseRunPipelineReturnType>((props) => {
@@ -42,6 +42,7 @@ export const RunButtons = React.memo<UseRunPipelineReturnType>((props) => {
   const dispatch = useDispatch()
 
   const runBtnOption = useSelector(selectPipelineRunBtn)
+  const runAlreadyDisabled = useSelector(selectRunAlreadyDisabled)
 
   const [dialogOpen, setDialogOpen] = React.useState(false)
   const { enqueueSnackbar } = useSnackbar()
@@ -132,7 +133,7 @@ export const RunButtons = React.memo<UseRunPipelineReturnType>((props) => {
                     <MenuItem
                       key={option}
                       disabled={
-                        !uidExists && option === RUN_BTN_OPTIONS.RUN_ALREADY
+                        (!uidExists || runAlreadyDisabled) && option === RUN_BTN_OPTIONS.RUN_ALREADY
                       }
                       selected={option === runBtnOption}
                       onClick={(event) => handleMenuItemClick(event, option)}

--- a/frontend/src/pages/Projects/Create.tsx
+++ b/frontend/src/pages/Projects/Create.tsx
@@ -700,7 +700,12 @@ const ProjectFormComponent = () => {
                 onCancle()
               }
             }
-            dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
+            dispatch(
+              setRunBtnOption({
+                runBtnOption: RUN_BTN_OPTIONS.RUN_NEW,
+                runAlreadyDisabled: true,
+              }),
+            )
             setLoading(false)
           },
         }),
@@ -714,7 +719,12 @@ const ProjectFormComponent = () => {
             if (isSuccess) {
               return onCancle()
             }
-            dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
+            dispatch(
+              setRunBtnOption({
+                runBtnOption: RUN_BTN_OPTIONS.RUN_NEW,
+                runAlreadyDisabled: true,
+              }),
+            )
             setLoading(false)
           },
         }),

--- a/frontend/src/pages/Projects/Create.tsx
+++ b/frontend/src/pages/Projects/Create.tsx
@@ -57,6 +57,8 @@ import { selectCurrentProject } from 'store/slice/Project/ProjectSelector'
 import { resetCurrentProject } from 'store/slice/Project/ProjectSlice'
 import { reset } from 'store/slice/Dataset/DatasetSlice'
 import { setLoadingExpriment } from 'store/slice/Experiments/ExperimentsSlice'
+import { setRunBtnOption } from 'store/slice/Pipeline/PipelineSlice'
+import { RUN_BTN_OPTIONS } from 'store/slice/Pipeline/PipelineType'
 
 const columns: Column[] = [
   { title: 'Lab', name: 'lab_name', filter: true, width: 100 },
@@ -698,12 +700,13 @@ const ProjectFormComponent = () => {
                 onCancle()
               }
             }
+            dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
             setLoading(false)
           },
         }),
-      )
-    } else {
-      dispatch(
+        )
+      } else {
+        dispatch(
         createProject({
           project,
           dataset,
@@ -711,6 +714,7 @@ const ProjectFormComponent = () => {
             if (isSuccess) {
               return onCancle()
             }
+            dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
             setLoading(false)
           },
         }),

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -79,7 +79,12 @@ export function useRunPipeline() {
                   dayjs(dayjs(finished_at).format('YYYY-MM-DD HH:mm')),
                   'm',
                 ) > 0
-                imgsetUpdatedSinceLastRun && dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
+                imgsetUpdatedSinceLastRun && dispatch(
+                  setRunBtnOption({
+                    runBtnOption: RUN_BTN_OPTIONS.RUN_NEW,
+                    runAlreadyDisabled: true,
+                  }),
+                )
               })
               .catch((_) => {
                 appDispatch(

--- a/frontend/src/store/slice/Pipeline/PipelineHook.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineHook.ts
@@ -9,11 +9,11 @@ import {
   selectPipelineStatus,
 } from './PipelineSelectors'
 import { run, pollRunResult, runByCurrentUid } from './PipelineActions'
-import { cancelPipeline, setAllowRun } from './PipelineSlice'
+import { cancelPipeline, setRunBtnOption } from './PipelineSlice'
 import { selectFilePathIsUndefined } from '../InputNode/InputNodeSelectors'
 import { selectAlgorithmNodeNotExist } from '../AlgorithmNode/AlgorithmNodeSelectors'
 import { useSnackbar } from 'notistack'
-import { RUN_STATUS } from './PipelineType'
+import { RUN_BTN_OPTIONS, RUN_STATUS } from './PipelineType'
 import {
   fetchExperiment,
   getExperiments,
@@ -73,20 +73,18 @@ export function useRunPipeline() {
             appDispatch(fetchExperiment({ projectId, urls }))
               .unwrap()
               .then(({ data: { finished_at } }) => {
-                const diffMinus = dayjs(
+                const imgsetUpdatedSinceLastRun = dayjs(
                   dayjs(last_updated_time).format('YYYY-MM-DD HH:mm'),
                 ).diff(
                   dayjs(dayjs(finished_at).format('YYYY-MM-DD HH:mm')),
                   'm',
-                )
-                dispatch(setAllowRun({ allowRun: diffMinus > 0 }))
+                ) > 0
+                imgsetUpdatedSinceLastRun && dispatch(setRunBtnOption({ runBtnOption: RUN_BTN_OPTIONS.RUN_NEW }))
               })
               .catch((_) => {
                 appDispatch(
                   importExperimentByUid({ uid: 'default', urls }),
-                ).then((_) => {
-                  dispatch(setAllowRun({ allowRun: true }))
-                })
+                )
               })
           })
       } else {

--- a/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
@@ -24,10 +24,6 @@ export const selectPipelineRunBtn = (state: RootState) => {
   return state.pipeline.runBtn
 }
 
-export const selectAllowRunButton = (state: RootState) => {
-  return state.pipeline.allowRun
-}
-
 export const selectRunResultPendingList = (state: RootState) => {
   const pipeline = selectStartedPipeline(state)
   if (isStartedPipeline(pipeline)) {

--- a/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSelectors.ts
@@ -24,6 +24,11 @@ export const selectPipelineRunBtn = (state: RootState) => {
   return state.pipeline.runBtn
 }
 
+export const selectRunAlreadyDisabled = (state: RootState) => {
+  return state.pipeline.runAlreadyDisabled ?? false
+}
+
+
 export const selectRunResultPendingList = (state: RootState) => {
   const pipeline = selectStartedPipeline(state)
   if (isStartedPipeline(pipeline)) {

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -32,14 +32,17 @@ export const pipelineSlice = createSlice({
   reducers: {
     cancelPipeline(state) {
       state.run.status = RUN_STATUS.CANCELED
+      state.runAlreadyDisabled = false
     },
     setRunBtnOption: (
       state,
       action: PayloadAction<{
         runBtnOption: RUN_BTN_TYPE
+        runAlreadyDisabled?: boolean
       }>,
     ) => {
       state.runBtn = action.payload.runBtnOption
+      state.runAlreadyDisabled = action.payload.runAlreadyDisabled ?? false
     },
   },
   extraReducers: (builder) => {
@@ -56,15 +59,20 @@ export const pipelineSlice = createSlice({
           if (runResultPendingList.length === 0) {
             // 終了
             state.run.status = RUN_STATUS.FINISHED
+            state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
+            state.runAlreadyDisabled = false
           }
         }
       })
       .addCase(pollRunResult.rejected, (state, action) => {
         state.run.status = RUN_STATUS.ABORTED
+        state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
+        state.runAlreadyDisabled = false
       })
       .addCase(importExperimentByUid.fulfilled, (state, action) => {
         if (action.meta.arg.uid === 'default') {
           state.runBtn = RUN_BTN_OPTIONS.RUN_NEW
+          state.runAlreadyDisabled = true
         } else {
           state.currentPipeline = {
             uid: action.meta.arg.uid,
@@ -80,6 +88,7 @@ export const pipelineSlice = createSlice({
           uid: action.payload.data.unique_id,
         }
         state.runBtn = RUN_BTN_OPTIONS.RUN_ALREADY
+        state.runAlreadyDisabled = false
         state.run = {
           uid: action.payload.data.unique_id,
           status: RUN_STATUS.START_SUCCESS,

--- a/frontend/src/store/slice/Pipeline/PipelineSlice.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineSlice.ts
@@ -24,7 +24,6 @@ const initialState: Pipeline = {
     status: RUN_STATUS.START_UNINITIALIZED,
   },
   runBtn: RUN_BTN_OPTIONS.RUN_NEW,
-  allowRun: true,
 }
 
 export const pipelineSlice = createSlice({
@@ -41,14 +40,6 @@ export const pipelineSlice = createSlice({
       }>,
     ) => {
       state.runBtn = action.payload.runBtnOption
-    },
-    setAllowRun: (
-      state,
-      action: PayloadAction<{
-        allowRun: boolean
-      }>,
-    ) => {
-      state.allowRun = action.payload.allowRun
     },
   },
   extraReducers: (builder) => {
@@ -137,7 +128,6 @@ export const pipelineSlice = createSlice({
           state.currentPipeline = {
             uid: action.payload,
           }
-          state.allowRun = false
         },
       )
       .addMatcher(
@@ -151,7 +141,6 @@ export const pipelineSlice = createSlice({
   },
 })
 
-export const { cancelPipeline, setRunBtnOption, setAllowRun } =
-  pipelineSlice.actions
+export const { cancelPipeline, setRunBtnOption } = pipelineSlice.actions
 
 export default pipelineSlice.reducer

--- a/frontend/src/store/slice/Pipeline/PipelineType.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineType.ts
@@ -11,6 +11,7 @@ export type Pipeline = {
     uid: string
   }
   runBtn: RUN_BTN_TYPE
+  runAlreadyDisabled?: boolean
 }
 
 export const RUN_STATUS = {

--- a/frontend/src/store/slice/Pipeline/PipelineType.ts
+++ b/frontend/src/store/slice/Pipeline/PipelineType.ts
@@ -11,7 +11,6 @@ export type Pipeline = {
     uid: string
   }
   runBtn: RUN_BTN_TYPE
-  allowRun: boolean
 }
 
 export const RUN_STATUS = {


### PR DESCRIPTION
#112 

以下のタイミングでRUN -> RUN ALLに変更するように修正
- Imagesetが前回WF実行時から更新されている場合
  - fetchされたexperimentのfinished_atよりもdatasetのlast_updated_timeが後
- EDIT IMAGESETでImagesetを変更した(OKをクリックした)場合
- Alignment Dialogで編集を確定した(OKをクリックした)場合

合わせて、以下の対応を実施

- allowRunに関連する処理は本実装の意図が伝わらず進んでいた実装だったため削除
- ワークフロー終了時にRUN ALLボタンがRUNになるように修正
  - optinistでは終了後もRUN ALLのまま
  - 本プロダクトでは以下の通り表示内容に相違が発生するため、前者を変更することで対応
    - ワークフロー画面から遷移せずにワークフロー終了 → RUN ALL
    - ワークフロー終了後にリロードなどでアクセス → RUN