### PR TITLE
superuser作成スクリプト

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -70,7 +70,7 @@ class User(BaseModel):
     email: EmailStr
     display_name: Optional[str]
     created_time: Optional[datetime] = None
-    role: int
+    role: Optional[int]
     lab: Optional[str]
     last_login_time: Optional[datetime] = None
 

--- a/set_superuser.py
+++ b/set_superuser.py
@@ -1,0 +1,25 @@
+import argparse
+import asyncio
+
+from backend.models.user import UserUpdate
+from backend.service.firebase.crud_user import update_user, read_user
+
+
+async def set_superuser(user_id: str, lab: str):
+    user = await read_user(user_id)
+    print(user)
+    updated_user = await update_user(
+        user_id,
+        UserUpdate(display_name=user.display_name, lab=lab, role=1),
+    )
+    print(updated_user)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--uid", help="ID of the firebase user to be set as the admin")
+    parser.add_argument("--lab", help="Lab name")
+
+    args = parser.parse_args()
+
+    asyncio.run(set_superuser(args.uid, args.lab))

--- a/set_superuser.py
+++ b/set_superuser.py
@@ -5,12 +5,12 @@ from backend.models.user import UserUpdate
 from backend.service.firebase.crud_user import update_user, read_user
 
 
-async def set_superuser(user_id: str, lab: str):
+async def set_superuser(user_id: str, lab: str, name: str):
     user = await read_user(user_id)
     print(user)
     updated_user = await update_user(
         user_id,
-        UserUpdate(display_name=user.display_name, lab=lab, role=1),
+        UserUpdate(display_name=name, lab=lab, role=1),
     )
     print(updated_user)
 
@@ -19,7 +19,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--uid", help="ID of the firebase user to be set as the admin")
     parser.add_argument("--lab", help="Lab name")
+    parser.add_argument("--name", help="Display name")
 
     args = parser.parse_args()
 
-    asyncio.run(set_superuser(args.uid, args.lab))
+    asyncio.run(set_superuser(args.uid, args.lab, args.name))


### PR DESCRIPTION
#165 

対象のfirebaseのシークレットが配置された状態のプロジェクトルートで以下のように実行する形式で作成

```
$ python set_superuser.py --uid FIREBASE_USER_ID --lab LAB_NAME
```

実行前後の情報がわかるようにprintは残しています


検証であれば、テストのFirebase環境でadmin以外の権限のユーザーを用意(またはadminからrole変更で降格)させてからスクリプトを実行していただければOKです。
UIDはFirebaseのコンソールのAuthenticationメニューから確認できます。